### PR TITLE
Preserve output

### DIFF
--- a/include/ADOConnection.h
+++ b/include/ADOConnection.h
@@ -11,7 +11,7 @@ Version History
 #ifndef ADO_CONNECTION_H
 #define ADO_CONNECTION_H
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #import "msado15.dll"  \
     rename( "EOF", "AdoNSEOF" )
@@ -31,7 +31,7 @@ class ADOConnection
 	   HRESULT hr;
 	   _bstr_t bstrConnect;
 }; /* end class ADOConnection */
-#else /* not WIN32 */
+#else /* not _WIN32 */
 /******************************************************************************
 class ADOConnection
 ******************************************************************************/
@@ -42,6 +42,6 @@ class ADOConnection
      void Read(char * table, char * keyColumn, char * key, char * column, char * name, char * fileName);
      void Write(char * table, char * keyColumn, char * key, char * column, const char * param);
 }; /* end class ADOConnection */
-#endif /* not WIN32 */
+#endif /* not _WIN32 */
 #endif /* ADO_CONNECTION_H */
 

--- a/include/FileList.h
+++ b/include/FileList.h
@@ -28,7 +28,7 @@ class FileList
       ~FileList(void){ DBG_PRINT("FileList::DTOR"); Destroy(); }
       void Destroy(void);
       void Insert(IroncladString name);
-      void Cleanup(IroncladString dir);
+      void Cleanup(IroncladString dir, const char* dirName, int rank);
       FileList * GetNext(void){ return m_pNxt;}
       IroncladString GetName(void){ return m_Name;}
 

--- a/include/MyHeaderInc.h
+++ b/include/MyHeaderInc.h
@@ -21,7 +21,7 @@ Version History
 #include "GeometryUtility.h" // Point, Circle, etc. data structs
 
 /* macros for access and chdir */
-#ifdef WIN32
+#ifdef _WIN32
   #include <direct.h>
   #include <io.h>
   #define MY_ACCESS _access

--- a/src/ADOConnection.cpp
+++ b/src/ADOConnection.cpp
@@ -10,7 +10,7 @@ Version History
 ******************************************************************************/
 #include "ADOConnection.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <string>
 #include <iostream>
 using namespace std;
@@ -143,7 +143,7 @@ void ADOConnection::Write(char * table, char * keyColumn, char * key, char * col
     CoUninitialize();
 }/* end Write */
 
-#else /* not WIN32, no support */
+#else /* not _WIN32, no support */
 /******************************************************************************
 CTOR
 
@@ -169,5 +169,5 @@ Writes to an ADO database.
 void ADOConnection::Write(char * table, char * keyColumn, char * key, char * column, const char * param)
 {
 }/* end Write */
-#endif /* not WIN32 */
+#endif /* not _WIN32 */
 

--- a/src/AdvancedKinniburgh.cpp
+++ b/src/AdvancedKinniburgh.cpp
@@ -183,6 +183,7 @@ int AdvancedKinniburgh(void)
       LogError(ERR_CONTINUE, "   TothIsotherm");
       LogError(ERR_CONTINUE, "**********************************");
 
+      pIso = NULL;
       delete [] pStr;
       ExitProgram(1);
    }

--- a/src/BinaryGA.cpp
+++ b/src/BinaryGA.cpp
@@ -129,6 +129,9 @@ void BinaryGA::Optimize(void)
    double medFitness;
    //double avgFitness;
    Chromosome * pBest;
+
+   // Initialize pointers for compiler
+   pBest = NULL;
         
    MPI_Comm_rank(MPI_COMM_WORLD, &id);   
 

--- a/src/ChromosomePool.cpp
+++ b/src/ChromosomePool.cpp
@@ -985,7 +985,10 @@ void ChromosomePool::Initialize(void)
           upr = m_Proto->GetGenePtr(j)->GetUpr();
           pLHS->InitRow(j, lwr, upr);
       }/* end for() */
-   }/* end if() */
+   }
+   else {
+       pVals = NULL;
+   }
 
    lvl = idx = 0;
    for(i = 0; i < m_PoolSize; i++)

--- a/src/ComboSA.cpp
+++ b/src/ComboSA.cpp
@@ -260,6 +260,10 @@ double ComboSA::Melt(double initVal)
       pdE      = new double[m_NumMelts];
       MEM_CHECK(m_pMelts);
    }
+   else {
+       pdE = new double[m_NumMelts];
+       MEM_CHECK(m_pMelts);
+   }
 
    Ebest = Ecur = initVal;
    dE = dEavg = 0.00;

--- a/src/FileList.cpp
+++ b/src/FileList.cpp
@@ -81,7 +81,7 @@ void FileList::Cleanup(IroncladString dir)
       }
       if(MY_ACCESS(tmp, 0) != -1)
       {
-         #ifdef WIN32
+         #ifdef _WIN32
             sprintf(tmp, "del %s 1>> %s 2>>&1", pCur->GetName(), GetOstExeOut());
          #else
             sprintf(tmp, "rm %s 2>&1 | >> %s", pCur->GetName(), GetOstExeOut());

--- a/src/FileList.cpp
+++ b/src/FileList.cpp
@@ -12,7 +12,6 @@ Version History
 07-05-08    lsm   created
 ******************************************************************************/
 #include <string.h>
-#include <stdlib.h>
 
 #include "FileList.h"
 
@@ -64,9 +63,9 @@ Cleanup()
 
 Delete the files in the list.
 ******************************************************************************/
-void FileList::Cleanup(IroncladString dir)
+void FileList::Cleanup(IroncladString dir, const char* dirName, int rank)
 {
-   static bool bLogged = false;  //only log once to reduce output file size
+   //static bool bLogged = false;  //only log once to reduce output file size
    char tmp[DEF_STR_SZ];
    FileList * pCur;
    MY_CHDIR(dir);
@@ -87,13 +86,16 @@ void FileList::Cleanup(IroncladString dir)
             sprintf(tmp, "rm %s 2>&1 | >> %s", pCur->GetName(), GetOstExeOut());
          #endif
          system(tmp);
-         if(bLogged == false)
-         {         
-            sprintf(tmp, "Ostrich deleted %s/%s", dir, pCur->GetName());
-            LogError(ERR_CLEANUP, tmp);
-         }/* end if(logged) */
+                 
+        sprintf(tmp, "Ostrich deleted %s/%s", dir, pCur->GetName());
+        LogError(ERR_CLEANUP, tmp);
       }/* end if(file exists) */
    }/* end for(each file) */
-   bLogged = true;
-   MY_CHDIR("..");
+    #ifdef _WIN32
+        sprintf(tmp, "..\\..\\..\\%s%d", dirName, rank);
+    #else
+        sprintf(tmp, "../../../%s%d", dirName, rank);
+        std::cout << tmp << std::endl;
+    #endif
+   MY_CHDIR(tmp);
 }/* end Cleanup() */

--- a/src/GeneticAlgorithm.cpp
+++ b/src/GeneticAlgorithm.cpp
@@ -135,6 +135,9 @@ void GeneticAlgorithm::Optimize(void)
    double medFitness;
    //double avgFitness;
    Chromosome * pBest;
+
+   // Initilize the pointers for the compiler
+   pBest = NULL;
         
    MPI_Comm_rank(MPI_COMM_WORLD, &id);
 

--- a/src/IsoFit.cpp
+++ b/src/IsoFit.cpp
@@ -160,6 +160,7 @@ int Isotherm(bool bSave)
       LogError(ERR_CONTINUE, "   TothIsotherm");
       LogError(ERR_CONTINUE, "**********************************");
 
+      pIso = NULL;
       delete [] pStr;
       ExitProgram(1);
    }

--- a/src/IsoParse.cpp
+++ b/src/IsoParse.cpp
@@ -1251,6 +1251,9 @@ void ISO_CreateParamList(IsoParamList * pList, IsoGlobStruct * pArgs)
    IsoParamList * pTmp;
    char * pCur;
 
+   // Initialize pointers for the compiler
+   pTmp = NULL;
+
    if(strcmp(pArgs->isoStr, "LinearIsotherm") == 0)
    {
       strcpy(pList->name, "KdVal");

--- a/src/Kinniburgh.cpp
+++ b/src/Kinniburgh.cpp
@@ -193,6 +193,7 @@ int Kinniburgh(bool bSave)
       LogError(ERR_CONTINUE, "   TothIsotherm");
       LogError(ERR_CONTINUE, "**********************************");
 
+      pIso = NULL;
       delete [] pStr;
       ExitProgram(1);
    }

--- a/src/McCammon.cpp
+++ b/src/McCammon.cpp
@@ -177,6 +177,7 @@ int McCammon(bool bSave)
       LogError(ERR_CONTINUE, "   TothIsotherm");
       LogError(ERR_CONTINUE, "**********************************");
 
+      pIso = NULL;
       delete [] pStr;
       ExitProgram(1);
    }

--- a/src/MemoryTracker.cpp
+++ b/src/MemoryTracker.cpp
@@ -26,7 +26,7 @@ double GetMemUsage(void)
 }
 #else
 
-#ifdef WIN32
+#ifdef _WIN32
   #include "windows.h"
   #include "psapi.h"
 #else
@@ -35,7 +35,7 @@ double GetMemUsage(void)
 #endif
 
 extern "C" {   
-#ifndef WIN32
+#ifndef _WIN32
    double parseLine(char* line);
    double getVmSize(void);
    double getVmRSS(void);
@@ -52,7 +52,7 @@ http://stackoverflow.com/questions/63166/how-to-determine-cpu-and-memory-consump
 ******************************************************************************/
 double GetMemUsage(void)
 {  
-#ifdef WIN32
+#ifdef _WIN32
    MEMORYSTATUSEX memInfo;
    memInfo.dwLength = sizeof(MEMORYSTATUSEX);
    GlobalMemoryStatusEx(&memInfo);
@@ -114,7 +114,7 @@ void LogMemUsage(char * file, const char * tag)
    if(file == NULL) pFile = stdout;
    else pFile = fopen(file, "a");
 
-#ifdef WIN32
+#ifdef _WIN32
    MEMORYSTATUSEX memInfo;
    memInfo.dwLength = sizeof(MEMORYSTATUSEX);
    GlobalMemoryStatusEx(&memInfo);
@@ -173,7 +173,7 @@ void LogMemUsage(char * file, const char * tag)
 }/* end ShowPhysMemUsage() */
 
 
-#ifndef WIN32
+#ifndef _WIN32
    double parseLine(char* line)
    {
       int i = strlen(line);

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -54,7 +54,6 @@ Version History
 #include <mpi.h>
 #include <math.h>
 #include <string.h>
-#include <stdlib.h>
 
 #include "Model.h"
 #include "ObservationGroup.h"
@@ -151,23 +150,31 @@ void Model::PreserveModel(int rank, int trial, int counter, IroncladString ofcat
       IroncladString dirName = GetExeDirName();
 
       #ifdef _WIN32
-         sprintf(tmp, "mkdir %%TMP%%\\mod%drun%d", rank, counter); //use temp dir for temporary location, due to xcopy rules
-         system(tmp);
-         sprintf(tmp, "dir /B run* > Exclude.txt"); //need to exclude previous 'run' directories
-         system(tmp); 
-         sprintf(tmp, "xcopy * %%TMP%%\\mod%drun%d /S /EXCLUDE:Exclude.txt >> %s", rank, counter, GetOstExeOut());  //perform copy
-         system(tmp);
-         sprintf(tmp, "move %%TMP%%\\mod%drun%d .\\run%d >> %s", rank, counter, counter, GetOstExeOut());  //relocate the directory
-         system(tmp);
+        // Create the archive directory
+        sprintf(tmp, "mkdir ..\\archive\\%s%d\\run_%d >> %s", m_DirPrefix, rank, counter, GetOstExeOut());
+        system(tmp);
+
+        // Get the the files in the working directory
+        sprintf(tmp, "dir /B run* > Exclude.txt"); //need to exclude previous 'run' directories
+        system(tmp);
+
+        // Copy the data
+        sprintf(tmp, "xcopy * ..\\archive\\%s%d\\run_%d /S /EXCLUDE:Exclude.txt >> %s", m_DirPrefix, rank, counter, GetOstExeOut());  //perform copy
+        system(tmp);
+
+        sprintf(tmp, "..\\archive\\%s%d\\run_%d", m_DirPrefix, rank, counter);
+
       #else
-         sprintf(tmp, "mkdir run%d", counter);
-         system(tmp);
-         sprintf(tmp, "cp * run%d 2>&1 | >> %s", counter, GetOstExeOut());
-         system(tmp);
+        sprintf(tmp, "mkdir -p ../archive/%s%d/run_%d", m_DirPrefix, rank, counter);
+        system(tmp);
+        sprintf(tmp, "cp * ../archive/%s%d/run_%d 2>&1 | >> %s", m_DirPrefix, rank, counter, GetOstExeOut());
+        system(tmp);
+
+        sprintf(tmp, "../archive/%s%d/run_%d", m_DirPrefix, rank, counter);
       #endif
 
-      sprintf(tmp, "run%d", counter);
-      m_pFileCleanupList->Cleanup(tmp);
+
+      m_pFileCleanupList->Cleanup(tmp, m_DirPrefix, rank);
    }/* end if() */
    /* run the user-supplied preservation command */
    else
@@ -387,7 +394,6 @@ Model::Model(void)
       }
       if(MY_ACCESS(tmp2, 0 ) == -1)
       {
-         sprintf(tmp1, "Model executable (|%s|) not found", tmp2);
          LogError(ERR_FILE_IO, tmp1);
          ExitProgram(1);
       }
@@ -1037,7 +1043,7 @@ void Model::Destroy(void)
       IroncladString dirName = GetExeDirName(); 
       if(dirName[0] != '.')
       {
-         m_pFileCleanupList->Cleanup(dirName);         
+         m_pFileCleanupList->Cleanup(dirName, m_DirPrefix, 0);         
       }
       delete m_pFileCleanupList;
    }

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -150,7 +150,7 @@ void Model::PreserveModel(int rank, int trial, int counter, IroncladString ofcat
    {
       IroncladString dirName = GetExeDirName();
 
-      #ifdef WIN32
+      #ifdef _WIN32
          sprintf(tmp, "mkdir %%TMP%%\\mod%drun%d", rank, counter); //use temp dir for temporary location, due to xcopy rules
          system(tmp);
          sprintf(tmp, "dir /B run* > Exclude.txt"); //need to exclude previous 'run' directories
@@ -174,7 +174,7 @@ void Model::PreserveModel(int rank, int trial, int counter, IroncladString ofcat
    {
       sprintf(tmp, "%s %d %d %d %s", m_PreserveCmd, rank, trial, counter, ofcat); 
 
-      #ifdef WIN32 //windows version
+      #ifdef _WIN32 //windows version
          strcat(tmp, " > OstPreserveModelOut.txt");
       #else //Linux (bash, dash, and csh)
          // '>&' redircts both output and error
@@ -234,7 +234,7 @@ Model::Model(void)
    m_NumCacheHits = 0;
    m_firstCall = true;
 
-   #ifdef WIN32
+   #ifdef _WIN32
       m_pFileCleanupList = new FileList("Ostrich.exe");
    #else
       m_pFileCleanupList = new FileList("Ostrich");
@@ -366,7 +366,7 @@ Model::Model(void)
 
    if((pDirName[0] != '.') && (m_InternalModel == false))
    {      
-      #ifdef WIN32
+      #ifdef _WIN32
          sprintf(tmp2, "copy %s %s", tmp1, pDirName);
       #else
          sprintf(tmp2, "cp %s %s", tmp1, pDirName);
@@ -392,7 +392,7 @@ Model::Model(void)
          ExitProgram(1);
       }
 
-      #ifdef WIN32 //windows version
+      #ifdef _WIN32 //windows version
          strcat(tmp1, " > ");
          strcat(tmp1, GetOstExeOut());
       #else //Linux (bash, dash, csh)
@@ -433,7 +433,7 @@ Model::Model(void)
       if(pDirName[0] != '.')
       {
          strcpy(tmp3, pDirName);
-         #ifdef WIN32
+         #ifdef _WIN32
             strcat(tmp3, "\\");
          #else
             strcat(tmp3, "/");
@@ -475,7 +475,7 @@ Model::Model(void)
 
          if(pDirName[0] != '.')
          {
-            #ifdef WIN32
+            #ifdef _WIN32
                sprintf(tmp2, "copy %s %s", tmp1, pDirName);
             #else
                sprintf(tmp2, "cp %s %s", tmp1, pDirName);
@@ -509,7 +509,7 @@ Model::Model(void)
 
          if(pDirName[0] != '.')
          {
-            #ifdef WIN32
+            #ifdef _WIN32
                sprintf(tmp2, "xcopy /S /E /I %s %s\\%s", tmp1, pDirName, tmp1);
             #else
                sprintf(tmp2, "cp -R %s %s", tmp1, pDirName);
@@ -570,7 +570,7 @@ Model::Model(void)
 
       if(pDirName[0] != '.')
       {
-         #ifdef WIN32
+         #ifdef _WIN32
             sprintf(tmp2, "copy %s %s", tmp1, pDirName);
          #else
             sprintf(tmp2, "cp %s %s", tmp1, pDirName);
@@ -594,7 +594,7 @@ Model::Model(void)
          ExitProgram(1);
       }
 
-      #ifdef WIN32 //windows version
+      #ifdef _WIN32 //windows version
          strcat(tmp1, " > OstSaveOut.txt");
       #else //Linux (bash, dash, and csh)
          strcpy(tmp2, tmp1);
@@ -722,7 +722,7 @@ Model::Model(void)
          //stage to workdir if needed
          if(pDirName[0] != '.')
          {
-            #ifdef WIN32
+            #ifdef _WIN32
                sprintf(tmp2, "copy %s %s", tmp1, pDirName);
             #else
                sprintf(tmp2, "cp %s %s", tmp1, pDirName);

--- a/src/Orear.cpp
+++ b/src/Orear.cpp
@@ -167,6 +167,7 @@ int Orear(void)
       LogError(ERR_CONTINUE, "   TothIsotherm");
       LogError(ERR_CONTINUE, "**********************************");
 
+      pIso = NULL;
       delete [] pStr;
       ExitProgram(1);
    }

--- a/src/Ostrich.cpp
+++ b/src/Ostrich.cpp
@@ -66,10 +66,6 @@ int main(int argc, StringType argv[])
    Windows uses a non-standard 3-digit exponent that messes up 
    applications that rely on standard 2-digit fixed formatting.
    --------------------------------------------------------------------*/
-#ifdef WIN32
-      _set_output_format(_TWO_DIGIT_EXPONENT);
-#endif
-
    //initialize time tracker
    GetElapsedTime();
 

--- a/src/PADDS.cpp
+++ b/src/PADDS.cpp
@@ -631,7 +631,7 @@ void PADDS::Calc_Z(ArchiveStruct * archive)
                double F1 = pSorted[i - 1]->F[obj];
                double F2 = pSorted[i + 1]->F[obj];
                double F4 = pSorted[archive_size - 1]->F[obj];
-					pSorted[i]->Z += abs(F1 - F2) / abs(F0 - F4);
+					pSorted[i]->Z += fabs(F1 - F2) / fabs(F0 - F4);
 				}
 
             if(archive_size > 1)

--- a/src/PDDSAlgorithm.cpp
+++ b/src/PDDSAlgorithm.cpp
@@ -383,6 +383,9 @@ void PDDSAlgorithm::Optimize(void)
    ParameterGroup * pGroup = m_pModel->GetParamGroupPtr();
    int nSpecial = pGroup->GetNumSpecialParams();
    double Fbest, * Cbest;
+
+   // Initilize cbest for the compiler
+   Cbest = NULL;
    
    //write setup
    WriteSetup(m_pModel, "Parallel Dynamically Dimensioned Search Algorithm (PDDS)");

--- a/src/ParaPADDS.cpp
+++ b/src/ParaPADDS.cpp
@@ -937,7 +937,7 @@ void ParaPADDS::Calc_Z(ArchiveStruct * archive)
                double F1 = pSorted[i - 1]->F[obj];
                double F2 = pSorted[i + 1]->F[obj];
                double F4 = pSorted[archive_size - 1]->F[obj];
-               pSorted[i]->Z += abs(F1 - F2) / abs(F0 - F4);
+               pSorted[i]->Z += fabs(F1 - F2) / fabs(F0 - F4);
             }
 
             if(archive_size > 1)

--- a/src/ParameterCorrection.cpp
+++ b/src/ParameterCorrection.cpp
@@ -110,7 +110,7 @@ ParameterCorrection::ParameterCorrection(ParameterGroup * pGroup)
             ExitProgram(1);
          }
 
-         #ifdef WIN32 //windows version
+         #ifdef _WIN32 //windows version
             strcat(tmp1, " > OstParameterCorrectionOut.txt");
          #else //Linux (bash, dash, csh)
             strcpy(tmp2, tmp1);

--- a/src/SAAlgorithm.cpp
+++ b/src/SAAlgorithm.cpp
@@ -658,6 +658,10 @@ double SAAlgorithm::Melt(double initVal)
       pdE      = new double[m_NumMelts];
       MEM_CHECK(pdE);
    }
+   else {
+       pdE = new double[m_NumMelts];
+       MEM_CHECK(pdE);
+   }
 
    while(CheckOverflow(initVal*initVal) == true)
    {
@@ -832,6 +836,10 @@ double SAAlgorithm::MeltMaster(double fbest, int nprocs)
       m_pMelts = new double[m_NumMelts];
       pdE = new double[m_NumMelts];
       MEM_CHECK(pdE);
+   }
+   else {
+       pdE = new double[m_NumMelts];
+       MEM_CHECK(pdE);
    }
 
    pGroup = m_pModel->GetParamGroupPtr();

--- a/src/StatsClass.cpp
+++ b/src/StatsClass.cpp
@@ -2501,7 +2501,7 @@ void StatsClass::CalcBestBoxCox(void)
    }
    
    //Create BoxCoxIn.tpl
-   #ifdef WIN32
+   #ifdef _WIN32
    system("mkdir BoxCoxModel 2> NUL");
    FILE * pTpl = fopen(".\\BoxCoxModel\\BoxCoxIn.tpl", "w");
    #else
@@ -2546,7 +2546,7 @@ void StatsClass::CalcBestBoxCox(void)
    fclose(pTpl);
 
    //create input file
-   #ifdef WIN32
+   #ifdef _WIN32
    FILE * pIn = fopen(".\\BoxCoxModel\\ostIn.txt", "w");
    #else
    FILE * pIn = fopen("./BoxCoxModel/ostIn.txt", "w");
@@ -2603,7 +2603,7 @@ End1dSearch\n");
    MyStrRep(OstExe, "IsoFit", "Ostrich");
    MyStrRep(OstExe, "OstrichMPI", "Ostrich");
    MyStrRep(OstExe, "OstrichFMPI", "Ostrich");
-   #ifdef WIN32
+   #ifdef _WIN32
       sprintf(cmd, "cd BoxCoxModel & %s > NUL & cd ..", OstExe);
    #else
       sprintf(cmd, "cd BoxCoxModel; %s > /dev/null; cd ..", OstExe);
@@ -2612,12 +2612,13 @@ End1dSearch\n");
    system(cmd);
 
    //retrieve result   
-   #ifdef WIN32
-   max_line_size = GetMaxLineSizeInFile(".\\BoxCoxModel\\OstOutput0.txt");
-   FILE * pOut = fopen(".\\BoxCoxModel\\OstOutput0.txt", "r");   
+   #ifdef _WIN32
+    char boxCoxName[] = ".\\BoxCoxModel\\OstOutput0.txt";
+    max_line_size = GetMaxLineSizeInFile(boxCoxName);
+    FILE * pOut = fopen(".\\BoxCoxModel\\OstOutput0.txt", "r");   
    #else
-   max_line_size = GetMaxLineSizeInFile((char *)"./BoxCoxModel/OstOutput0.txt");
-   FILE * pOut = fopen("./BoxCoxModel/OstOutput0.txt", "r");
+    max_line_size = GetMaxLineSizeInFile((char *)"./BoxCoxModel/OstOutput0.txt");
+    FILE * pOut = fopen("./BoxCoxModel/OstOutput0.txt", "r");
    #endif
    line = new char[max_line_size];
    if(pOut == NULL)
@@ -4214,7 +4215,7 @@ void StatsClass::WriteResiduals(int step, char * prefix)
    // previously recorded value is best
    else if (fprevbest < fcur) 
    {
-      #ifdef WIN32
+      #ifdef _WIN32
          sprintf(cmd, "copy %s %s", pname, fname);
       #else
          sprintf(cmd, "cp %s %s", pname, fname);
@@ -4467,7 +4468,10 @@ void EVAL_Program(int argc, StringType argv[])
          pList[i] = new double[num+1];
          MEM_CHECK(pList[i]);
       }
-   }/* end if() */
+   }
+   else {
+       pList = NULL;
+   }
 
    //read in entries
    rewind(pFile);

--- a/src/SuperMUSE.cpp
+++ b/src/SuperMUSE.cpp
@@ -25,7 +25,7 @@ Version History
 #include "Exception.h"
 
 //definition of sleep() is platform-dependent
-#ifdef WIN32
+#ifdef _WIN32
    #include <Windows.h> //needed for Sleep() and GetWindowsDirectory() commands
 #else
    #include <unistd.h> //needed for sleep() command
@@ -291,7 +291,7 @@ bool SuperMUSE::WaitForTasker(void)
    nticks = 0;
    while(1)
    {
-#ifdef WIN32
+#ifdef _WIN32
       Sleep(1000); //1 second polling intervals
 #else
       sleep(1); //1 second polling intervals
@@ -410,7 +410,7 @@ void SuperMUSE::EnvVarCleanup(void)
    //replace environment vars used in temp, task, success, error files
    m_pEnvVars = NULL;
    char iemVarsFile[1000];
-   #ifdef WIN32
+   #ifdef _WIN32
    GetWindowsDirectoryA(iemVarsFile, 1000);
    #else
    strcpy(iemVarsFile, "");

--- a/src/SurrogateModel.cpp
+++ b/src/SurrogateModel.cpp
@@ -115,7 +115,7 @@ SurrogateModel::SurrogateModel
       ExitProgram(1);
    }
 
-   #ifdef WIN32 //windows version
+   #ifdef _WIN32 //windows version
       strcat(tmp1, " > ");
       strcat(tmp1, GetOstExeOut());
    #else
@@ -155,7 +155,7 @@ SurrogateModel::SurrogateModel
       if(pDir[0] != '.')
       {
          strcpy(tmp3, pDir);
-         #ifdef WIN32
+         #ifdef _WIN32
             strcat(tmp3, "\\");
          #else
             strcat(tmp3, "/");

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -38,11 +38,11 @@ Version History
 #include "Utility.h"
 #include "Exception.h"
 
-#ifndef WIN32
+#ifndef _WIN32
    #include <sys/time.h>
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
   #include <string>
   using namespace std;
 #endif
@@ -213,7 +213,7 @@ bool IsNonDominated(double * pF, int nObj)
    }
    else
    {
-#ifdef WIN32
+#ifdef _WIN32
       sprintf(prefix, "..\\OstModel");
 #else
       sprintf(prefix, "../OstModel");
@@ -675,7 +675,7 @@ void ConvertToASCII(void)
       j = ExtractString(lineStr, tmpFileName);
       lineStr += j;
 	   //deletes converted file, if it exists
-      #ifdef WIN32
+      #ifdef _WIN32
         string s_fileName(tmpFileName);
         s_fileName = s_fileName.substr(0, s_fileName.find_last_of('.'));
         s_fileName += ".txt";
@@ -2108,7 +2108,7 @@ Get the time elapsed (in clock tics) from the start of the program.
 ******************************************************************************/
 double GetElapsedTics(void)
 {
-#ifdef WIN32
+#ifdef _WIN32
   long long tics, tics_per_sec;
   QueryPerformanceCounter((LARGE_INTEGER *)&tics);
   QueryPerformanceFrequency((LARGE_INTEGER *)&tics_per_sec);
@@ -2413,7 +2413,7 @@ void ExecuteCommandLine(IroncladString cmd, bool isRead, IroncladString fileName
 	char output[DEF_STR_SZ];
    FILE * pPipe;
 
-   #ifdef WIN32
+   #ifdef _WIN32
       pPipe = _popen(cmd, "rt");
 	   if (isRead)
 	   {


### PR DESCRIPTION
This corrects #14 and #15 on windows systems. It creates an archive folder on the current drive to preserve output rather than passing it through a temp folder on the c drive. To keep consistency, the linux preservation has been reworked to the same format.

Windows flags have been updated for VS2019 compilers. 