### PR TITLE
Add missing include of iostream in FileList.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+make/Ostrich

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 *.out
 *.app
 make/Ostrich
+
+# MacOS files
+**.DS_Store

--- a/include/FileList.h
+++ b/include/FileList.h
@@ -4,7 +4,7 @@ Author   : L. Shawn Matott
 Copyright: 2008, L. Shawn Matott
 
 FileList classes are used to store a collection of files that Ostrich needs to
-delete when its done running. These files are executables and and extra input 
+delete when its done running. These files are executables and and extra input
 files.  Files are deleted to conserve disk space, which is required for large
 parallel runs.
 
@@ -15,6 +15,7 @@ Version History
 #define FILE_LIST_H
 
 #include "MyHeaderInc.h"
+#include <iostream>
 
 /******************************************************************************
 class FileList
@@ -34,10 +35,7 @@ class FileList
 
    private:
       char m_Name[DEF_STR_SZ];
-      FileList * m_pNxt;      
+      FileList * m_pNxt;
 }; /* end class FileList */
 
 #endif /* FILE_LIST_H */
-
-
-

--- a/include/FileList.h
+++ b/include/FileList.h
@@ -15,7 +15,6 @@ Version History
 #define FILE_LIST_H
 
 #include "MyHeaderInc.h"
-#include <iostream>
 
 /******************************************************************************
 class FileList

--- a/src/FileList.cpp
+++ b/src/FileList.cpp
@@ -4,7 +4,7 @@ Author   : L. Shawn Matott
 Copyright: 2008, L. Shawn Matott
 
 FileList classes are used to store a collection of files that Ostrich needs to
-delete when its done running. These files are executables and and extra input 
+delete when its done running. These files are executables and and extra input
 files.  Files are deleted to conserve disk space, which is required for large
 parallel runs.
 
@@ -25,8 +25,8 @@ Creates a file list.
 ******************************************************************************/
 FileList::FileList(IroncladString name)
 {
-   strcpy(m_Name, name); 
-   m_pNxt = NULL; 
+   strcpy(m_Name, name);
+   m_pNxt = NULL;
    IncCtorCount();
 } /* end CTOR */
 
@@ -36,7 +36,7 @@ Destroy()
 Frees up the file list.
 ******************************************************************************/
 void FileList::Destroy(void)
-{   
+{
    delete m_pNxt;
    IncDtorCount();
 }/* end Destroy() */
@@ -86,7 +86,7 @@ void FileList::Cleanup(IroncladString dir, const char* dirName, int rank)
             sprintf(tmp, "rm %s 2>&1 | >> %s", pCur->GetName(), GetOstExeOut());
          #endif
          system(tmp);
-                 
+
         sprintf(tmp, "Ostrich deleted %s/%s", dir, pCur->GetName());
         LogError(ERR_CLEANUP, tmp);
       }/* end if(file exists) */
@@ -95,7 +95,6 @@ void FileList::Cleanup(IroncladString dir, const char* dirName, int rank)
         sprintf(tmp, "..\\..\\..\\%s%d", dirName, rank);
     #else
         sprintf(tmp, "../../../%s%d", dirName, rank);
-        std::cout << tmp << std::endl;
     #endif
    MY_CHDIR(tmp);
 }/* end Cleanup() */


### PR DESCRIPTION
Just a tiny change. Does not compile on Unix systems without including `<iostream>` in FileList.h