### PR TITLE
Corrections to the gradient math

### DIFF
--- a/include/LevenbergAlgorithm2.h
+++ b/include/LevenbergAlgorithm2.h
@@ -30,6 +30,7 @@ Version History
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>
+#include <vector>
 
 // Include custom classes
 #include "Algorithm.h"

--- a/src/Algorithm.cpp
+++ b/src/Algorithm.cpp
@@ -1249,15 +1249,21 @@ void Algorithm::ManageSingleObjectiveIterations(std::vector<std::vector<double>>
     // If caching is enabled, check the solutions against the list of values to be created
     std::vector<int> indicesToSolve;
     for (int entryAlternative = startingIndex; entryAlternative < parameters.size(); entryAlternative++) {
-        if (m_bCaching) {
+        
+        if (parameters[entryAlternative].size() == 0) {
+            // The parameter set has been flagged as invalid for this analysis and shouldn't be computed. This is typically done for vector alignment purposes
+            // Set the resulting objective to infinity
+            returnArray[entryAlternative] = INFINITY;
+
+        } else if (m_bCaching) {
             // Caching is enabled. Check that the member is not in the cache
             std::vector<std::vector<double>> ::iterator itr = std::find(m_CacheMembers.begin(), m_CacheMembers.end(), parameters[entryAlternative]);
 
             if (itr == m_CacheMembers.end()) {
                 // Alternative is not present in the cache. Add it to be solved.
                 indicesToSolve.push_back(entryAlternative);
-            }
-            else {
+
+            } else {
                 // Log the cache hit
                 m_NumCacheHits++;
 

--- a/src/LevenbergAlgorithm2.cpp
+++ b/src/LevenbergAlgorithm2.cpp
@@ -328,6 +328,15 @@ void LevenbergAlgorithm::Optimize(void) {
             // Initialize the objectives for the solve
             objectivesJacobian = std::vector<double>(samples.size(), INFINITY);
 
+            // @@ debug. Check for nans in the sample matrix
+            for (int i_entry_alternative = 0; i_entry_alternative < samples.size(); i_entry_alternative++) {
+                for (int i_entry_parameter = 0; i_entry_parameter < samples[i_entry_alternative].size(); i_entry_parameter++) {
+                    if (std::isnan(samples[i_entry_alternative][i_entry_parameter])) {
+                        std::cout << "I found a nan!" << std::endl;
+                    }
+                }
+            }
+
             // Solve the samples
             ManageSingleObjectiveIterations(samples, 0, m_pParamGroup->GetNumParams(), objectivesJacobian);
 
@@ -401,13 +410,12 @@ void LevenbergAlgorithm::Optimize(void) {
                     if (lockedParameters[entryParameter]) {
                         delta[entryParameter] = m_BestAlternative[entryParameter];
                     } else {
-                        double parameterDelta = (jacobian[0][entryParameter] * (m_BestObjective - objectivesJacobian[entryParameter])) /
-                            (pow(jacobian[0][entryParameter], 2) * (1 + lambdas[entryLambda]));
+                        double parameterDelta = (jacobian[m_Iteration][entryParameter] * (m_BestObjective - objectivesJacobian[entryParameter])) /
+                            (pow(jacobian[m_Iteration][entryParameter], 2) * (1 + lambdas[entryLambda]));
 
                         // Append into the delta vector
                         delta[entryParameter] += parameterDelta + m_BestAlternative[entryParameter];
                     }
-
                 }
 
                 // Enforce lower parameter bounds
@@ -426,6 +434,15 @@ void LevenbergAlgorithm::Optimize(void) {
 
                 // Push into the sample vector for evalation
                 samples.push_back(delta);
+            }
+
+            // @@ debug. Check for nans in the sample matrix
+            for (int i_entry_alternative = 0; i_entry_alternative < samples.size(); i_entry_alternative++) {
+                for (int i_entry_parameter = 0; i_entry_parameter < samples[i_entry_alternative].size(); i_entry_parameter++) {
+                    if (std::isnan(samples[i_entry_alternative][i_entry_parameter])) {
+                        std::cout << "I found a nan!" << std::endl;
+                    }
+                }
             }
 
             // Evaluate the line search across the deltas
@@ -506,13 +523,6 @@ void LevenbergAlgorithm::Optimize(void) {
             m_BestObjective = bestObjectiveIteration;
             m_BestAlternative = bestAlterativeIteration;
         }
-        
-        // Adjust the step size if necessary
-        if (m_ObjectiveTolerance <= m_ObjectiveToleranceMaximum && m_StepSize >= m_StepToleranceMaximum) {
-            // Reduce the step size
-            m_StepSize /= m_StepSizeScaleFactor;
-        } 
-
 
         // Log the iteration
         // Set the values into the pointer groups
@@ -531,6 +541,12 @@ void LevenbergAlgorithm::Optimize(void) {
         if (!(m_Iteration < m_NumIterationMaximum && m_StepSize >= m_StepToleranceMaximum)) {
             continueIterations = false;
         } 
+
+        // Adjust the step size if necessary
+        if (m_ObjectiveTolerance <= m_ObjectiveToleranceMaximum && m_StepSize >= m_StepToleranceMaximum) {
+            // Reduce the step size
+            m_StepSize /= m_StepSizeScaleFactor;
+        }
 
         // Regenerate the jacobian sample matrix
         if (continueIterations) {

--- a/src/LevenbergAlgorithm2.cpp
+++ b/src/LevenbergAlgorithm2.cpp
@@ -328,15 +328,6 @@ void LevenbergAlgorithm::Optimize(void) {
             // Initialize the objectives for the solve
             objectivesJacobian = std::vector<double>(samples.size(), INFINITY);
 
-            // @@ debug. Check for nans in the sample matrix
-            for (int i_entry_alternative = 0; i_entry_alternative < samples.size(); i_entry_alternative++) {
-                for (int i_entry_parameter = 0; i_entry_parameter < samples[i_entry_alternative].size(); i_entry_parameter++) {
-                    if (std::isnan(samples[i_entry_alternative][i_entry_parameter])) {
-                        std::cout << "I found a nan!" << std::endl;
-                    }
-                }
-            }
-
             // Solve the samples
             ManageSingleObjectiveIterations(samples, 0, m_pParamGroup->GetNumParams(), objectivesJacobian);
 
@@ -434,15 +425,6 @@ void LevenbergAlgorithm::Optimize(void) {
 
                 // Push into the sample vector for evalation
                 samples.push_back(delta);
-            }
-
-            // @@ debug. Check for nans in the sample matrix
-            for (int i_entry_alternative = 0; i_entry_alternative < samples.size(); i_entry_alternative++) {
-                for (int i_entry_parameter = 0; i_entry_parameter < samples[i_entry_alternative].size(); i_entry_parameter++) {
-                    if (std::isnan(samples[i_entry_alternative][i_entry_parameter])) {
-                        std::cout << "I found a nan!" << std::endl;
-                    }
-                }
             }
 
             // Evaluate the line search across the deltas

--- a/src/MathClass2.cpp
+++ b/src/MathClass2.cpp
@@ -96,6 +96,11 @@ void CalculateJacobianParameters(std::vector<double> currentValues, std::vector<
 
             } else {
                 // Lock the parameter
+                // Create an empty vector to signify that the values aren't valid
+                std::vector<double> placeholder = {};
+                
+                // Add values to the vectors
+                jacobianLocations.push_back(placeholder);
                 lockedParameter.push_back(true);
             }
         }
@@ -123,6 +128,11 @@ void CalculateJacobianParameters(std::vector<double> currentValues, std::vector<
 
             } else {
                 // Indicate that the parameter is locked
+                // Create an empty vector to signify that the values aren't valid
+                std::vector<double> placeholder = {};
+
+                // Add values to the vectors
+                jacobianLocations.push_back(placeholder);
                 lockedParameter.push_back(true);
             }
         }
@@ -146,6 +156,11 @@ void CalculateJacobianParameters(std::vector<double> currentValues, std::vector<
 
             } else {
                 // Lock the parameter
+                // Create an empty vector to signify that the values aren't valid
+                std::vector<double> placeholder = {};
+
+                // Add values to the vectors
+                jacobianLocations.push_back(placeholder);
                 lockedParameter.push_back(true);
             }
         }
@@ -176,18 +191,17 @@ void CalculateJacobian2(std::vector<double> currentValues, double currentObjecti
                     lockedParameter[entryParameter] = true;
                 }
 
-                // Increment the index counter 
-                indexPosition++;
-
             } else {
                 // Parameter is locked. Add a zero into the derivative vector as a placeholder
                 functionDerivatives.push_back(0);
             }
+
+            // Increment the index counter 
+            indexPosition++;
         }
 
         // Append the function derivatives into the jacobian
         jacobian.push_back(functionDerivatives);
-
 
     } else if (order == FIRST_CENTRAL) {
         // First order central difference
@@ -207,13 +221,13 @@ void CalculateJacobian2(std::vector<double> currentValues, double currentObjecti
                     lockedParameter[entryParameter] = true;
                 }
 
-                // Increment the index counter 
-                indexPosition++;
-
             } else {
                 // Parameter is locked. Add a zero into the derivative vector as a placeholder
                 functionDerivatives.push_back(0);
             }
+
+            // Increment the index counter 
+            indexPosition++;
         }
 
         // Append the function derivatives into the jacobian
@@ -236,13 +250,13 @@ void CalculateJacobian2(std::vector<double> currentValues, double currentObjecti
                     lockedParameter[entryParameter] = true;
                 }
 
-                // Increment the index counter 
-                indexPosition++;
-
             } else {
                 // Parameter is locked. Add a zero into the derivative vector as a placeholder
                 functionDerivatives.push_back(0);
             }
+
+            // Increment the index counter 
+            indexPosition++;
         }
 
         // Append the function derivatives into the jacobian

--- a/src/ModelWorker.cpp
+++ b/src/ModelWorker.cpp
@@ -1236,6 +1236,7 @@ void ModelWorker::MoveModel(std::filesystem::path workerDirectoryPath, std::file
 
     // Iterate over the directory contents
     for (std::filesystem::path path : iterator) {
+        std::cout << path << std::endl;
         // Confirm that the path is to a file
         if (!std::filesystem::is_directory(path)) {
             // Check that the file is not an input file


### PR DESCRIPTION
This merge corrects some issues with the mathematics in the new gradient solver. The main changes are:

1.  Fixed an indexing bug in how the Jacobian was getting updated
2.  Two vectorization fixes to keep the data aligned between the alternatives and the samples
3.  Introduced a check in the solver engine to allow flagging of solutions by the length of the alternative vector. By passing an alternative with a length of zero, the alternative will not be solved. This can be used for vector alignment without the need to specifically handle alignment in each algorithm.